### PR TITLE
Modification for pile-up validation plots when we do JESC

### DIFF
--- a/JetUtilities/interface/SynchFittingProcedure.hh
+++ b/JetUtilities/interface/SynchFittingProcedure.hh
@@ -1026,6 +1026,7 @@ TCanvas * getGausMeanOffsetOverPtref(TString cname, TString ctitle, TString algo
    hh[0]->GetXaxis()->SetRangeUser(0,1000);
    hh[0]->GetXaxis()->SetMoreLogLabels();
    hh[0]->GetXaxis()->SetNoExponent();
+   hh[0]->Draw("E"); // Added by JhLee at Nov 14th, 2024 to draw pile-up plots
 
    for (unsigned int j=0;j<hh.size();j++) {
       //if(j==0)

--- a/JetUtilities/interface/SynchFittingProcedure.hh
+++ b/JetUtilities/interface/SynchFittingProcedure.hh
@@ -1026,7 +1026,7 @@ TCanvas * getGausMeanOffsetOverPtref(TString cname, TString ctitle, TString algo
    hh[0]->GetXaxis()->SetRangeUser(0,1000);
    hh[0]->GetXaxis()->SetMoreLogLabels();
    hh[0]->GetXaxis()->SetNoExponent();
-   hh[0]->Draw("E"); // Added by JhLee at Nov 14th, 2024 to draw pile-up plots
+   hh[0]->Draw("E"); // Added by Junghyun Lee at [ Nov 14th, 2024 ] to draw pile-up plots
 
    for (unsigned int j=0;j<hh.size();j++) {
       //if(j==0)


### PR DESCRIPTION
To properly create the pile-up plot, the Draw("E") method was first applied to hh[0] before using the tdrDraw function to render the histogram.